### PR TITLE
Moving from travis.ci to github-actions (#123)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,43 @@
+name: Build and Test
+
+on: [push, pull_request]
+
+env:
+  ROOT_VERSION: root_v6.24.06.Linux-ubuntu20-x86_64-gcc9.3.tar.gz
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install cmake and gtest
+      run: |
+        sudo apt-get install cmake libgtest-dev libglu1-mesa
+        sudo apt install libopengl0 -y
+        cd /usr/src/gtest
+        sudo cmake CMakeLists.txt
+        sudo make
+        cd -
+
+    - name: Install root
+      run: |
+        wget https://root.cern.ch/download/${ROOT_VERSION}
+        tar xzf ${ROOT_VERSION}
+        source root/bin/thisroot.sh
+       
+    - name: Build GenFit
+      run: |
+        source root/bin/thisroot.sh
+        cd ${{github.workspace}}/.. && mkdir build && cd build
+        cmake ../GenFit
+        make
+    
+    - name: Run Tests
+      run: |
+        source root/bin/thisroot.sh
+        cd ${{github.workspace}}/../build
+        ctest  --output-on-failure
+        
+


### PR DESCRIPTION
Since the travis.ci pipeline stopped working, moving the CI to github actions.